### PR TITLE
SIMPLYE-395: Rewrite reservation history fetch logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 POSTGRES_URL = "postgresql://palace:test@localhost:5432/circ"
 OPENSEARCH_URL = "http://localhost:9200"
 OPENSEARCH_EVENT_INDEX = "circulation-events-v1"
+OPENSEARCH_WORK_INDEX = "circulation-works-v5"
 ROOT_PATH = ""

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     POSTGRES_URL: str = ""
     OPENSEARCH_URL: str = ""
     OPENSEARCH_EVENT_INDEX: str = ""
+    OPENSEARCH_WORK_INDEX: str = ""
     ROOT_PATH: str = ""
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")

--- a/lib/models.py
+++ b/lib/models.py
@@ -1,23 +1,11 @@
 from pydantic import BaseModel
 
 
-class LibMeta(BaseModel):
-    collection: str
-    page: int
-    page_size: int
-    total: int
-
-
 class Reservation(BaseModel):
     count: int
     identifier: str
     title: str
     author: str
-
-
-class Reservations(BaseModel):
-    meta: LibMeta
-    data: list[Reservation]
 
 
 class TokenData(BaseModel):

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from lib.database import (
     get_holds_with_edition_data,
     get_reservations_for_identifier,
 )
-from lib.models import Reservation, Reservations, TokenData
+from lib.models import Reservation, TokenData
 from lib.opensearch import get_os_client, get_reservation_events
 
 app = FastAPI(
@@ -80,8 +80,6 @@ def read_active_reservations_for_license_pool(
 @app.get("/reservation-history")
 def read_reservation_history(
     os_client: OpenSearch = Depends(get_os_client),
-    page: int = 1,
-    size: int = 100,
     from_date: datetime.date | None = Query(
         default=None,
         alias="from",
@@ -93,12 +91,10 @@ def read_reservation_history(
         description="Format: YYYY-MM-DD",
     ),
     token_data: TokenData = Depends(get_token_data),
-) -> Reservations:
+) -> list[Reservation]:
     return get_reservation_events(
         os_client=os_client,
         collection_name=token_data.collection_name,
-        page=page,
-        size=size,
         from_date=from_date,
         to_date=to_date,
     )

--- a/tests/opensearch_testsetup.py
+++ b/tests/opensearch_testsetup.py
@@ -1,40 +1,88 @@
 from unittest.mock import MagicMock
+from config import settings
+
+mock_event_response = {
+    "hits": {"total": {"value": 7, "relation": "eq"}, "hits": []},
+    "aggregations": {
+        "identifier": {
+            "doc_count_error_upper_bound": 0,
+            "sum_other_doc_count": 0,
+            "buckets": [
+                {
+                    "key": "111",
+                    "doc_count": 3,
+                },
+                {
+                    "key": "222",
+                    "doc_count": 2,
+                },
+                {
+                    "key": "333",
+                    "doc_count": 1,
+                },
+            ],
+        }
+    },
+}
 
 
-mock_search_response = {
+mock_works_response = {
     "hits": {
         "total": {"value": 3, "relation": "eq"},
         "hits": [
             {
                 "_source": {
-                    "identifier": "111",
+                    "identifiers": [
+                        {
+                            "type": "ISBN",
+                            "identifier": "111",
+                        }
+                    ],
                     "title": "Book 1",
                     "author": "Author 1",
-                    "start": "2024-02-01T10:00:00.148927+00:00",
                 }
             },
             {
                 "_source": {
-                    "identifier": "111",
-                    "title": "Book 1",
-                    "author": "Author 1",
-                    "start": "2024-03-01T06:27:16.148927+00:00",
-                }
-            },
-            {
-                "_source": {
-                    "identifier": "222",
+                    "identifiers": [
+                        {
+                            "type": "ISBN",
+                            "identifier": "222",
+                        }
+                    ],
                     "title": "Book 2",
                     "author": "Author 2",
-                    "start": "2024-04-01T06:27:16.148927+00:00",
+                }
+            },
+            {
+                "_source": {
+                    "identifiers": [
+                        {
+                            "type": "ISBN",
+                            "identifier": "333",
+                        }
+                    ],
+                    "title": "Book 3",
+                    "author": "Author 2",
                 }
             },
         ],
     }
 }
 
+
+def mock_search_side_effect(*args, **kwargs):
+    if kwargs["index"] == settings.OPENSEARCH_EVENT_INDEX:
+        return mock_event_response
+    elif kwargs["index"] == settings.OPENSEARCH_WORK_INDEX:
+        return mock_works_response
+    else:
+        raise ValueError("Unexpected index")
+
+
+# Create and configure the mock
 mock_os_client = MagicMock()
-mock_os_client.search.return_value = mock_search_response
+mock_os_client.search.side_effect = mock_search_side_effect
 
 
 def override_get_os_client():

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -91,8 +91,22 @@ class TestReservationHistory(unittest.TestCase):
         assert response.status_code == 200
 
         output = response.json()
-        assert len(output["data"]) == 2
-        # First book has two reservations
-        assert output["data"][0]["count"] == 2
-        # Second book has one reservation
-        assert output["data"][1]["count"] == 1
+        assert len(output) == 3
+        # Get the books by identifiers
+        book_map = {item["identifier"]: item for item in output}
+        first_book = book_map.get("111", {})
+        second_book = book_map.get("222", {})
+        third_book = book_map.get("333", {})
+        # Test counts
+        assert first_book["count"] == 3
+        assert second_book["count"] == 2
+        assert third_book["count"] == 1
+        # Test identifiers
+        assert first_book["identifier"] == "111"
+        assert second_book["identifier"] == "222"
+        assert third_book["identifier"] == "333"
+        # Test title and author fields
+        assert first_book["title"] == "Book 1"
+        assert first_book["author"] == "Author 1"
+        assert second_book["title"] == "Book 2"
+        assert second_book["author"] == "Author 2"


### PR DESCRIPTION
Reservation history endpoint had a logical mishap and results in larger data amounts are broken.

History fetch logic rewritten to do the individual work reservation event count in OpenSearch with aggregation and fetch work info from work index in separate call. Pagination is removed.

NOTE: New environmental variable OPENSEARCH_WORK_INDEX

Context: https://jira.lingsoft.fi/browse/SIMPLYE-395