### PR TITLE
add aarch64 platform

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -74,6 +74,11 @@ jobs:
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -100,6 +105,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
This pull request updates the `.github/workflows/test-build.yaml` workflow to improve support for building Docker images for `amd64` and `arm64`.

* Added a step to set up QEMU for emulation of the `arm64`.
